### PR TITLE
feat: add extend UI page with period selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
   - [Database Structure](#database-structure)
 - [API](#api)
   - [GET /extend](#get-extend)
+  - [GET /extend/apply](#get-extendapply)
   - [GET /api/environments](#get-apienvironments)
   - [POST /api/environments](#post-apienvironments)
 - [Notifications](#notifications)
@@ -140,13 +141,22 @@ Table `tokens`:
 
 ### GET /extend
 
-Extends the specified environment for the specified period.
+Serves an interactive HTML page where the user can choose an extension period for their environment. The page displays environment info (name, type, owner, scheduled deletion date) and three buttons with period options (min, mid, max). This route does not require basic auth - the token parameter provides security.
+
+Parameters:
+
+- `env_id` - environment ID in the database.
+- `token` - one-time token for extending the environment.
+
+### GET /extend/apply
+
+Extends the specified environment for the specified period. Returns a JSON response. Called by the extend UI page via JavaScript.
 
 Parameters:
 
 - `env_id` - environment ID in the database.
 - `period` - extension period (e.g. `2d`, `4d`, `1w`). Maximum is specified in the configuration. Exceeding it returns an error.
-- `token` - one-time token for extending the environment. A unique token is generated for each stale notification and included in the extend links. After a single use the token is deleted, preventing repeated extensions via the same link.
+- `token` - one-time token for extending the environment. A unique token is generated for each stale notification and included in the extend link. After a single use the token is deleted, preventing repeated extensions via the same link.
 
 ### GET /api/environments
 
@@ -184,13 +194,10 @@ You need to move the environment to the blacklist, add metadata manually, or mov
 Environment release-name (namespace: release-ns), type: helm,
 is stale and will be deleted in <stale_threshold>
 
-Use one of the following links to extend your environment:
-- [Extend <min_period>]
-- [Extend <mid_period>]
-- [Extend <max_period>]
+[Extend your environment]
 ```
 
-The environment has less than `stale_threshold` left until deletion. A notification is sent to the user with a suggestion to extend the environment. Extension periods are calculated dynamically: `min` equals `stale_threshold`, `max` equals `max_extend_duration`, and `mid` is half of `max`.
+The environment has less than `stale_threshold` left until deletion. A notification is sent to the user with a link to the extend UI page. On the page, the user can choose one of three extension periods: `min` equals `stale_threshold`, `max` equals `max_extend_duration`, and `mid` is half of `max`.
 
 ### Environment Has Been Deleted
 

--- a/contrib/scripts/generate_test_token.sh
+++ b/contrib/scripts/generate_test_token.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DB_PATH="${1:-}"
+
+if [ -z "$DB_PATH" ]; then
+  echo "Usage: $0 <path-to-env.db>"
+  exit 1
+fi
+
+if [ ! -f "$DB_PATH" ]; then
+  echo "Error: database file not found: $DB_PATH"
+  exit 1
+fi
+
+if ! command -v sqlite3 &>/dev/null; then
+  echo "Error: sqlite3 is not installed"
+  exit 1
+fi
+
+ENV_ID=$(sqlite3 "$DB_PATH" "SELECT env_id FROM environments LIMIT 1;")
+
+if [ -z "$ENV_ID" ]; then
+  echo "Error: no environments found in database"
+  exit 1
+fi
+
+TOKEN=$(openssl rand -hex 16)
+
+sqlite3 "$DB_PATH" "INSERT OR REPLACE INTO tokens (env_id, token) VALUES ('$ENV_ID', '$TOKEN');"
+
+ENV_NAME=$(sqlite3 "$DB_PATH" "SELECT name FROM environments WHERE env_id = '$ENV_ID';")
+ENV_NS=$(sqlite3 "$DB_PATH" "SELECT namespace FROM environments WHERE env_id = '$ENV_ID';")
+
+echo "Token generated for environment:"
+echo "  env_id:    $ENV_ID"
+echo "  name:      $ENV_NAME"
+echo "  namespace: $ENV_NS"
+echo "  token:     $TOKEN"
+echo ""
+echo "Extend URL: http://localhost:8080/extend?env_id=${ENV_ID}&token=${TOKEN}"

--- a/internal/api/environments_handler.go
+++ b/internal/api/environments_handler.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"encoding/json"
-	"fmt"
 	"log/slog"
 	"net/http"
 )
@@ -74,16 +73,9 @@ func (h *EnvironmentHandler) ExtendEnvironment(
 		slog.String("type", env.Type),
 		slog.String("id", env.EnvID),
 		slog.String("period", period),
-		slog.String("token", token),
 	)
 
-	msg := fmt.Sprintf("Extended environment: %s, type: %s, period: %s",
-		env.DisplayName(), env.Type, period)
-	w.WriteHeader(http.StatusOK)
-	if _, err := fmt.Fprint(w, msg); err != nil {
-		slog.Error("error writing response",
-			slog.String("env_id", envID),
-			slog.Any("error", err),
-		)
-	}
+	sendSuccessResponse(
+		w, NewEnvironmentResponse(env),
+	)
 }

--- a/internal/api/extend_page.go
+++ b/internal/api/extend_page.go
@@ -1,0 +1,159 @@
+package api
+
+import (
+	_ "embed"
+	"html/template"
+	"log/slog"
+	"net/http"
+
+	"github.com/xhit/go-str2duration/v2"
+)
+
+//go:embed static/extend.html
+var extendHTML string
+
+//go:embed static/extend.css
+var extendCSS string
+
+//go:embed static/extend.js
+var extendJS string
+
+type extendPageData struct {
+	EnvID     string
+	Name      string
+	Type      string
+	Owner     string
+	DeleteAt  string
+	Token     string
+	PeriodMin string
+	PeriodMid string
+	PeriodMax string
+}
+
+type ExtendPageHandler struct {
+	service           EnvironmentService
+	staleThreshold    string
+	maxExtendDuration string
+	tmpl              *template.Template
+}
+
+func NewExtendPageHandler(
+	svc EnvironmentService,
+	staleThreshold string,
+	maxExtendDuration string,
+) *ExtendPageHandler {
+	tmpl := template.Must(
+		template.New("extend").Parse(extendHTML),
+	)
+	return &ExtendPageHandler{
+		service:           svc,
+		staleThreshold:    staleThreshold,
+		maxExtendDuration: maxExtendDuration,
+		tmpl:              tmpl,
+	}
+}
+
+func (h *ExtendPageHandler) ServePage(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	envID := r.URL.Query().Get("env_id")
+	token := r.URL.Query().Get("token")
+
+	if envID == "" || token == "" {
+		sendErrorResponse(
+			w, http.StatusBadRequest,
+			"missing env_id or token",
+		)
+		return
+	}
+
+	env, err := h.service.GetEnvironmentForExtend(
+		r.Context(), envID, token,
+	)
+	if err != nil {
+		handleServiceError(w, err, envID)
+		return
+	}
+
+	periods, err := calcExtendPeriods(
+		h.staleThreshold, h.maxExtendDuration,
+	)
+	if err != nil {
+		slog.Error("error calculating extend periods",
+			slog.Any("error", err),
+		)
+		sendErrorResponse(
+			w, http.StatusInternalServerError,
+			"internal server error",
+		)
+		return
+	}
+
+	data := extendPageData{
+		EnvID:     env.EnvID,
+		Name:      env.DisplayName(),
+		Type:      env.Type,
+		Owner:     env.Owner,
+		DeleteAt:  env.DeleteAt,
+		Token:     token,
+		PeriodMin: periods["min"],
+		PeriodMid: periods["mid"],
+		PeriodMax: periods["max"],
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := h.tmpl.Execute(w, data); err != nil {
+		slog.Error("error rendering template",
+			slog.Any("error", err),
+		)
+	}
+}
+
+func (h *ExtendPageHandler) ServeCSS(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	w.Header().Set("Content-Type", "text/css; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write([]byte(extendCSS)); err != nil {
+		slog.Error("error serving CSS",
+			slog.Any("error", err),
+		)
+	}
+}
+
+func (h *ExtendPageHandler) ServeJS(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	w.Header().Set(
+		"Content-Type",
+		"application/javascript; charset=utf-8",
+	)
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write([]byte(extendJS)); err != nil {
+		slog.Error("error serving JS",
+			slog.Any("error", err),
+		)
+	}
+}
+
+func calcExtendPeriods(
+	staleThreshold, maxExtendDuration string,
+) (map[string]string, error) {
+	maxDuration, err := str2duration.ParseDuration(
+		maxExtendDuration,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	midDuration := maxDuration / 2
+
+	return map[string]string{
+		"min": staleThreshold,
+		"mid": str2duration.String(midDuration),
+		"max": maxExtendDuration,
+	}, nil
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -21,6 +21,10 @@ const (
 type EnvironmentService interface {
 	GetEnvironments(ctx context.Context) ([]*model.Environment, error)
 	AddEnvironment(ctx context.Context, env *model.Environment, ttl string) error
+	GetEnvironmentForExtend(
+		ctx context.Context,
+		envID, token string,
+	) (*model.Environment, error)
 	ExtendEnvironment(
 		ctx context.Context,
 		envID, period, token string,
@@ -49,12 +53,41 @@ func (a *API) Run(ctx context.Context) error {
 	r.Use(middleware.RequestID)
 	r.Use(middleware.Logger)
 	r.Use(middleware.CleanPath)
-	r.Use(a.authMiddleware)
 
 	envHandler := NewEnvironmentHandler(a.service)
-	r.Get("/api/environments", envHandler.GetEnvironments)
-	r.Post("/api/environments", envHandler.AddEnvironment)
-	r.Get("/extend", envHandler.ExtendEnvironment)
+	extendPage := NewExtendPageHandler(
+		a.service,
+		a.Config.StaleThreshold,
+		a.Config.MaxExtendDuration,
+	)
+
+	r.Group(func(r chi.Router) {
+		r.Get("/extend", extendPage.ServePage)
+		r.Get(
+			"/extend/apply",
+			envHandler.ExtendEnvironment,
+		)
+		r.Get(
+			"/extend/static/extend.css",
+			extendPage.ServeCSS,
+		)
+		r.Get(
+			"/extend/static/extend.js",
+			extendPage.ServeJS,
+		)
+	})
+
+	r.Group(func(r chi.Router) {
+		r.Use(a.authMiddleware)
+		r.Get(
+			"/api/environments",
+			envHandler.GetEnvironments,
+		)
+		r.Post(
+			"/api/environments",
+			envHandler.AddEnvironment,
+		)
+	})
 
 	srv := &http.Server{
 		Addr:         ":8080",
@@ -78,7 +111,10 @@ func (a *API) Run(ctx context.Context) error {
 		defer cancel()
 
 		if err := srv.Shutdown(ctx); err != nil {
-			slog.Error("failed to shutdown API service gracefully", slog.Any("error", err))
+			slog.Error(
+				"failed to shutdown API service gracefully",
+				slog.Any("error", err),
+			)
 			return fmt.Errorf("failed to shutdown API service gracefully: %w", err)
 		}
 

--- a/internal/api/static/extend.css
+++ b/internal/api/static/extend.css
@@ -1,0 +1,117 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: #f0f4f8;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+}
+
+.card {
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 2px 16px rgba(0, 0, 0, 0.08);
+  padding: 36px 40px;
+  max-width: 420px;
+  width: 100%;
+}
+
+h1 {
+  font-size: 20px;
+  font-weight: 600;
+  color: #1a2332;
+  margin-bottom: 24px;
+}
+
+.env-info {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 28px;
+}
+
+.env-field {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.label {
+  font-size: 13px;
+  color: #6b7a8d;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+}
+
+.value {
+  font-size: 15px;
+  color: #1a2332;
+  font-weight: 500;
+}
+
+.hint {
+  font-size: 14px;
+  color: #6b7a8d;
+  margin-bottom: 14px;
+}
+
+.buttons {
+  display: flex;
+  gap: 10px;
+}
+
+.btn {
+  flex: 1;
+  padding: 10px 16px;
+  border: 1px solid #d1d9e0;
+  border-radius: 8px;
+  background: #f7f9fb;
+  color: #1a2332;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.btn:hover {
+  background: #e8eef3;
+  border-color: #b0bec5;
+}
+
+.btn:active {
+  background: #dce4eb;
+}
+
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.hidden {
+  display: none;
+}
+
+.result-success {
+  padding: 16px;
+  background: #e8f5e9;
+  border-radius: 8px;
+  color: #2e7d32;
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.result-error {
+  padding: 16px;
+  background: #fbe9e7;
+  border-radius: 8px;
+  color: #c62828;
+  font-size: 14px;
+  line-height: 1.5;
+}

--- a/internal/api/static/extend.html
+++ b/internal/api/static/extend.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Extend Environment</title>
+  <link rel="stylesheet" href="/extend/static/extend.css">
+</head>
+<body>
+  <div class="card">
+    <h1>Extend Environment</h1>
+    <div class="env-info">
+      <div class="env-field">
+        <span class="label">Name</span>
+        <span class="value" id="env-name">{{.Name}}</span>
+      </div>
+      <div class="env-field">
+        <span class="label">Type</span>
+        <span class="value" id="env-type">{{.Type}}</span>
+      </div>
+      <div class="env-field">
+        <span class="label">Owner</span>
+        <span class="value" id="env-owner">{{.Owner}}</span>
+      </div>
+      <div class="env-field">
+        <span class="label">Scheduled deletion</span>
+        <span class="value" id="env-delete-at">{{.DeleteAt}}</span>
+      </div>
+    </div>
+    <div id="actions">
+      <p class="hint">Choose extension period:</p>
+      <div class="buttons">
+        <button class="btn" onclick="extend('{{.PeriodMin}}')">{{.PeriodMin}}</button>
+        <button class="btn" onclick="extend('{{.PeriodMid}}')">{{.PeriodMid}}</button>
+        <button class="btn" onclick="extend('{{.PeriodMax}}')">{{.PeriodMax}}</button>
+      </div>
+    </div>
+    <div id="result" class="hidden"></div>
+  </div>
+  <script>
+    var envID = "{{.EnvID}}";
+    var token = "{{.Token}}";
+  </script>
+  <script src="/extend/static/extend.js"></script>
+</body>
+</html>

--- a/internal/api/static/extend.js
+++ b/internal/api/static/extend.js
@@ -1,0 +1,58 @@
+function extend(period) {
+  var buttons = document.querySelectorAll(".btn");
+  buttons.forEach(function (btn) {
+    btn.disabled = true;
+  });
+
+  var url =
+    "/extend/apply?env_id=" +
+    encodeURIComponent(envID) +
+    "&period=" +
+    encodeURIComponent(period) +
+    "&token=" +
+    encodeURIComponent(token);
+
+  fetch(url)
+    .then(function (resp) {
+      return resp.json().then(function (data) {
+        return { ok: resp.ok, data: data };
+      });
+    })
+    .then(function (result) {
+      var actions = document.getElementById("actions");
+      var resultDiv = document.getElementById("result");
+
+      actions.classList.add("hidden");
+      resultDiv.classList.remove("hidden");
+
+      if (result.ok && result.data.success) {
+        resultDiv.className = "result-success";
+        resultDiv.innerHTML =
+          "Environment extended by <strong>" +
+          period +
+          "</strong>.<br>New deletion date: <strong>" +
+          result.data.data.delete_at +
+          "</strong>";
+      } else {
+        resultDiv.className = "result-error";
+        var msg = "Failed to extend";
+        if (result.data.error) {
+          msg = result.data.error.message || msg;
+        }
+        resultDiv.textContent = msg;
+        buttons.forEach(function (btn) {
+          btn.disabled = false;
+        });
+        actions.classList.remove("hidden");
+      }
+    })
+    .catch(function () {
+      var resultDiv = document.getElementById("result");
+      resultDiv.classList.remove("hidden");
+      resultDiv.className = "result-error";
+      resultDiv.textContent = "Network error. Please try again.";
+      buttons.forEach(function (btn) {
+        btn.disabled = false;
+      });
+    });
+}

--- a/internal/notifications/notifications.go
+++ b/internal/notifications/notifications.go
@@ -4,17 +4,14 @@ import (
 	"fmt"
 	"log/slog"
 
-	"github.com/xhit/go-str2duration/v2"
-
 	"github.com/fragpit/env-cleaner/internal/model"
 	"github.com/fragpit/env-cleaner/pkg/notificator"
 )
 
 type Notificator struct {
-	adminOnly         bool
-	apiURL            string
-	staleThreshold    string
-	maxExtendDuration string
+	adminOnly      bool
+	apiURL         string
+	staleThreshold string
 	*SlackConfig
 	*EmailConfig
 }
@@ -44,12 +41,13 @@ func New(
 	adminOnly bool,
 	apiURL string,
 	staleThreshold string,
-	maxExtendDuration string,
 	slackCfg *SlackConfig,
 	emailCfg *EmailConfig,
 ) *Notificator {
 	if slackCfg.Enabled {
-		slackCfg.SlackNotificator = notificator.NewSlackNotificator(slackCfg.WebhookURL)
+		slackCfg.SlackNotificator = notificator.NewSlackNotificator(
+			slackCfg.WebhookURL,
+		)
 	}
 
 	if emailCfg.Enabled {
@@ -62,12 +60,11 @@ func New(
 	}
 
 	return &Notificator{
-		adminOnly:         adminOnly,
-		apiURL:            apiURL,
-		staleThreshold:    staleThreshold,
-		maxExtendDuration: maxExtendDuration,
-		SlackConfig:       slackCfg,
-		EmailConfig:       emailCfg,
+		adminOnly:      adminOnly,
+		apiURL:         apiURL,
+		staleThreshold: staleThreshold,
+		SlackConfig:    slackCfg,
+		EmailConfig:    emailCfg,
 	}
 }
 
@@ -77,10 +74,7 @@ var orphanMessage = `
 
 var staleMessage = `
 **Environment %s, type: %s, is stale and will be deleted in %s**
-Use one of the following links to extend your environment:
-- [Extend %[7]s](%[4]s/extend?env_id=%[5]s&period=%[7]s&token=%[6]s)
-- [Extend %[8]s](%[4]s/extend?env_id=%[5]s&period=%[8]s&token=%[6]s)
-- [Extend %[9]s](%[4]s/extend?env_id=%[5]s&period=%[9]s&token=%[6]s)
+[Extend your environment](%[4]s/extend?env_id=%[5]s&token=%[6]s)
 `
 
 var deleteMessage = `
@@ -120,7 +114,10 @@ func (nt *Notificator) SendOrphanMessage(env *model.Environment) error {
 	return nil
 }
 
-func (nt *Notificator) SendStaleMessage(env *model.Environment, tk *model.Token) error {
+func (nt *Notificator) SendStaleMessage(
+	env *model.Environment,
+	tk *model.Token,
+) error {
 	name := env.DisplayName()
 	slog.Info("sending stale message",
 		slog.String("environment", name),
@@ -134,10 +131,6 @@ func (nt *Notificator) SendStaleMessage(env *model.Environment, tk *model.Token)
 			slackChannel = nt.AdminChannel
 		}
 
-		extendPeriods, err := setExtendPeriods(nt.staleThreshold, nt.maxExtendDuration)
-		if err != nil {
-			return fmt.Errorf("error setting stale periods: %w", err)
-		}
 		msg, err := notificator.NewSlackMessage(
 			nt.SenderName,
 			slackChannel,
@@ -148,9 +141,6 @@ func (nt *Notificator) SendStaleMessage(env *model.Environment, tk *model.Token)
 				nt.apiURL,
 				env.EnvID,
 				tk.Token,
-				extendPeriods["min"],
-				extendPeriods["mid"],
-				extendPeriods["max"],
 			))
 
 		if err != nil {
@@ -162,7 +152,10 @@ func (nt *Notificator) SendStaleMessage(env *model.Environment, tk *model.Token)
 		if err := nt.SlackNotificator.Send(msg); err != nil {
 			return fmt.Errorf(
 				"error sending slack notification for environment %s, type: %s, id: %s: %w",
-				name, env.Type, env.EnvID, err,
+				name,
+				env.Type,
+				env.EnvID,
+				err,
 			)
 		}
 	}
@@ -202,25 +195,13 @@ func (nt *Notificator) SendDeleteMessage(env *model.Environment) error {
 		if err := nt.SlackNotificator.Send(msg); err != nil {
 			return fmt.Errorf(
 				"error sending slack notification for environment %s, type: %s, id: %s: %w",
-				name, env.Type, env.EnvID, err,
+				name,
+				env.Type,
+				env.EnvID,
+				err,
 			)
 		}
 	}
 
 	return nil
-}
-
-func setExtendPeriods(staleThreshold, maxExtendDuration string) (map[string]string, error) {
-	maxDuration, err := str2duration.ParseDuration(maxExtendDuration)
-	if err != nil {
-		return nil, fmt.Errorf("error parsing max extend duration: %w", err)
-	}
-
-	midDuration := maxDuration / 2
-
-	return map[string]string{
-		"min": staleThreshold,
-		"mid": str2duration.String(midDuration),
-		"max": maxExtendDuration,
-	}, nil
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -79,7 +79,6 @@ func Run() error {
 		cfg.Notifications.AdminOnly,
 		cfg.APIURL,
 		cfg.StaleThreshold,
-		cfg.MaxExtendDuration,
 		&notifications.SlackConfig{
 			Enabled:      cfg.Notifications.Slack.Enabled,
 			WebhookURL:   cfg.Notifications.Slack.WebhookURL,
@@ -104,7 +103,9 @@ func Run() error {
 	enabledConnectors := make(map[string]model.Connector)
 
 	if !cfg.Environments.VSphereVM.Enabled && !cfg.Environments.Helm.Enabled {
-		slog.Error("check environments configuration settings: no connectors enabled")
+		slog.Error(
+			"check environments configuration settings: no connectors enabled",
+		)
 		return err
 	}
 
@@ -175,7 +176,10 @@ func Run() error {
 	go func() {
 		defer wg.Done()
 		if err := a.Run(ctx); err != nil {
-			slog.Error("shutdown env-cleaner, error running API", slog.Any("error", err))
+			slog.Error(
+				"shutdown env-cleaner, error running API",
+				slog.Any("error", err),
+			)
 			cancel()
 		}
 	}()

--- a/internal/service/environment.go
+++ b/internal/service/environment.go
@@ -27,19 +27,29 @@ func NewEnvironmentService(
 	}
 }
 
-func (s *EnvironmentService) GetEnvironments(ctx context.Context) ([]*model.Environment, error) {
+func (s *EnvironmentService) GetEnvironments(
+	ctx context.Context,
+) ([]*model.Environment, error) {
 	return s.repo.GetEnvironments(ctx)
 }
 
-func (s *EnvironmentService) AddEnvironment(ctx context.Context, env *model.Environment, ttl string) error {
+func (s *EnvironmentService) AddEnvironment(
+	ctx context.Context,
+	env *model.Environment,
+	ttl string,
+) error {
 	conn, err := s.connectorFactory.GetConnector(env.Type)
 	if err != nil {
-		return &model.ValidationError{Msg: fmt.Sprintf("error getting connector: %v", err)}
+		return &model.ValidationError{
+			Msg: fmt.Sprintf("error getting connector: %v", err),
+		}
 	}
 
 	deleteAt, deleteAtSec, err := utils.SetDeleteAt(ttl)
 	if err != nil {
-		return &model.ValidationError{Msg: fmt.Sprintf("error setting delete ttl: %v", err)}
+		return &model.ValidationError{
+			Msg: fmt.Sprintf("error setting delete ttl: %v", err),
+		}
 	}
 
 	env.DeleteAt = deleteAt
@@ -47,11 +57,15 @@ func (s *EnvironmentService) AddEnvironment(ctx context.Context, env *model.Envi
 
 	env.EnvID, err = conn.GetEnvironmentID(ctx, env)
 	if err != nil {
-		return &model.ValidationError{Msg: fmt.Sprintf("error getting environment id: %v", err)}
+		return &model.ValidationError{
+			Msg: fmt.Sprintf("error getting environment id: %v", err),
+		}
 	}
 
 	if err := conn.CheckEnvironment(ctx, env); err != nil {
-		return &model.ValidationError{Msg: fmt.Sprintf("error checking environment: %v", err)}
+		return &model.ValidationError{
+			Msg: fmt.Sprintf("error checking environment: %v", err),
+		}
 	}
 
 	if _, err := s.repo.GetEnvByID(ctx, env.EnvID); err == nil {
@@ -66,29 +80,77 @@ func (s *EnvironmentService) AddEnvironment(ctx context.Context, env *model.Envi
 	return nil
 }
 
-func (s *EnvironmentService) ExtendEnvironment(ctx context.Context, envID, period, token string) (*model.Environment, error) {
+func (s *EnvironmentService) GetEnvironmentForExtend(
+	ctx context.Context,
+	envID, token string,
+) (*model.Environment, error) {
 	tk, err := s.repo.GetToken(ctx, envID)
 	if err != nil || tk.Token != token {
-		return nil, &model.ValidationError{Msg: "invalid token"}
-	}
-
-	if err := utils.PeriodValidate(period, s.maxExtendDuration); err != nil {
-		return nil, &model.ValidationError{Msg: fmt.Sprintf("invalid period: %v", err)}
+		return nil, &model.ValidationError{
+			Msg: "invalid token",
+		}
 	}
 
 	env, err := s.repo.GetEnvByID(ctx, envID)
 	if err != nil {
-		return nil, &model.NotFoundError{Msg: fmt.Sprintf("environment not found: %v", err)}
+		return nil, &model.NotFoundError{
+			Msg: fmt.Sprintf(
+				"environment not found: %v", err,
+			),
+		}
 	}
 
-	if err := s.repo.ExtendEnvironment(ctx, envID, period); err != nil {
-		return nil, fmt.Errorf("error extending environment: %w", err)
+	return env, nil
+}
+
+func (s *EnvironmentService) ExtendEnvironment(
+	ctx context.Context,
+	envID, period, token string,
+) (*model.Environment, error) {
+	tk, err := s.repo.GetToken(ctx, envID)
+	if err != nil || tk.Token != token {
+		return nil, &model.ValidationError{
+			Msg: "invalid token",
+		}
+	}
+
+	if err := utils.PeriodValidate(
+		period, s.maxExtendDuration,
+	); err != nil {
+		return nil, &model.ValidationError{
+			Msg: fmt.Sprintf("invalid period: %v", err),
+		}
+	}
+
+	env, err := s.repo.GetEnvByID(ctx, envID)
+	if err != nil {
+		return nil, &model.NotFoundError{
+			Msg: fmt.Sprintf(
+				"environment not found: %v", err,
+			),
+		}
+	}
+
+	if err := s.repo.ExtendEnvironment(
+		ctx, envID, period,
+	); err != nil {
+		return nil, fmt.Errorf(
+			"error extending environment: %w", err,
+		)
 	}
 
 	if err := s.repo.DeleteToken(ctx, env.EnvID); err != nil {
 		slog.Error("error deleting token",
 			slog.String("env_id", env.EnvID),
 			slog.Any("error", err),
+		)
+	}
+
+	env, err = s.repo.GetEnvByID(ctx, envID)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"error fetching updated environment: %w",
+			err,
 		)
 	}
 


### PR DESCRIPTION
## Summary

- Add interactive HTML page for `/extend` endpoint that displays environment info (name, type, owner, deletion date) and 3 buttons to choose extension period
- Split routes into public (token-secured `/extend/*`) and authenticated (`/api/*`) groups so users can access extend links from Slack notifications without basic auth
- Simplify stale notification message from 3 separate period links to a single link that opens the UI page
- Move period calculation logic from notifications to API package (`calcExtendPeriods`)
- Return JSON response from extend apply endpoint for JS consumption
- Add helper script `contrib/scripts/generate_test_token.sh` for local testing

## Test plan

- [x] Build passes: `go build ./...`
- [x] Open `/extend?env_id=<id>&token=<token>` in browser - verify page renders with env info and 3 buttons
- [x] Click an extend button - verify success message with new deletion date appears
- [x] Open `/extend` without params - verify error response
- [x] Open `/extend` with invalid token - verify error response
- [x] Verify `/api/environments` still requires basic auth
- [x] Verify stale Slack notification contains single extend link