### PR TITLE
style: apply golines formatting across the project

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -66,7 +66,10 @@ func init() {
 	rootCmd.PersistentFlags().
 		BoolVarP(&Debug, "debug", "d", false, "Enable debug mode (default: false)")
 
-	if err := viper.BindPFlag("debug", rootCmd.PersistentFlags().Lookup("debug")); err != nil {
+	if err := viper.BindPFlag(
+		"debug",
+		rootCmd.PersistentFlags().Lookup("debug"),
+	); err != nil {
 		slog.Error("error binding flag", slog.Any("error", err))
 	}
 

--- a/internal/api/helpers.go
+++ b/internal/api/helpers.go
@@ -65,16 +65,32 @@ func handleServiceError(
 
 	switch {
 	case errors.As(err, &ve):
-		slog.Error("validation error", slog.String("subject", subject), slog.Any("error", err))
+		slog.Error(
+			"validation error",
+			slog.String("subject", subject),
+			slog.Any("error", err),
+		)
 		sendErrorResponse(w, http.StatusBadRequest, ve.Msg)
 	case errors.As(err, &nf):
-		slog.Error("not found", slog.String("subject", subject), slog.Any("error", err))
+		slog.Error(
+			"not found",
+			slog.String("subject", subject),
+			slog.Any("error", err),
+		)
 		sendErrorResponse(w, http.StatusNotFound, nf.Msg)
 	case errors.As(err, &ce):
-		slog.Warn("conflict", slog.String("subject", subject), slog.Any("error", err))
+		slog.Warn(
+			"conflict",
+			slog.String("subject", subject),
+			slog.Any("error", err),
+		)
 		sendErrorResponse(w, http.StatusConflict, ce.Msg)
 	default:
-		slog.Error("internal error", slog.String("subject", subject), slog.Any("error", err))
+		slog.Error(
+			"internal error",
+			slog.String("subject", subject),
+			slog.Any("error", err),
+		)
 		sendErrorResponse(
 			w,
 			http.StatusInternalServerError,

--- a/internal/connectors/helm/helm.go
+++ b/internal/connectors/helm/helm.go
@@ -85,7 +85,12 @@ func (h *Connector) GetEnvironments(
 ) ([]model.Environment, error) {
 	actionConfig := new(action.Configuration)
 
-	if err := actionConfig.Init(h.HelmClient.RESTClientGetter(), "", "", slogInfof); err != nil {
+	if err := actionConfig.Init(
+		h.HelmClient.RESTClientGetter(),
+		"",
+		"",
+		slogInfof,
+	); err != nil {
 		return nil, fmt.Errorf("error getting releases: %w", err)
 	}
 
@@ -108,7 +113,10 @@ func (h *Connector) GetEnvironments(
 	}
 
 	if len(results) == 0 {
-		slog.Info("no helm releases found for specified filter", slog.String("filter", filter))
+		slog.Info(
+			"no helm releases found for specified filter",
+			slog.String("filter", filter),
+		)
 		return nil, nil
 	}
 
@@ -173,7 +181,12 @@ func (h *Connector) GetEnvironmentID(
 	h.HelmClient.SetNamespace(env.Namespace)
 	actionConfig := new(action.Configuration)
 
-	if err := actionConfig.Init(h.HelmClient.RESTClientGetter(), env.Namespace, "", slogInfof); err != nil {
+	if err := actionConfig.Init(
+		h.HelmClient.RESTClientGetter(),
+		env.Namespace,
+		"",
+		slogInfof,
+	); err != nil {
 		return "", fmt.Errorf("error getting release: %w", err)
 	}
 
@@ -220,7 +233,12 @@ func (h *Connector) DeleteEnvironment(
 	h.HelmClient.SetNamespace(env.Namespace)
 	actionConfig := new(action.Configuration)
 
-	if err := actionConfig.Init(h.HelmClient.RESTClientGetter(), env.Namespace, "", slogDebugf); err != nil {
+	if err := actionConfig.Init(
+		h.HelmClient.RESTClientGetter(),
+		env.Namespace,
+		"",
+		slogDebugf,
+	); err != nil {
 		return fmt.Errorf("error deleting release: %w", err)
 	}
 
@@ -298,7 +316,12 @@ func scaleDeployment(
 	sc := *s
 	sc.Spec.Replicas = replicas
 
-	if _, err = client.UpdateScale(ctx, deploymentName, &sc, metav1.UpdateOptions{}); err != nil {
+	if _, err = client.UpdateScale(
+		ctx,
+		deploymentName,
+		&sc,
+		metav1.UpdateOptions{},
+	); err != nil {
 		return err
 	}
 
@@ -319,7 +342,12 @@ func scaleStatefulSet(
 	sc := *s
 	sc.Spec.Replicas = replicas
 
-	if _, err := client.UpdateScale(ctx, statefulsetName, &sc, metav1.UpdateOptions{}); err != nil {
+	if _, err := client.UpdateScale(
+		ctx,
+		statefulsetName,
+		&sc,
+		metav1.UpdateOptions{},
+	); err != nil {
 		return err
 	}
 

--- a/internal/connectors/vsphere/vsphere.go
+++ b/internal/connectors/vsphere/vsphere.go
@@ -110,7 +110,10 @@ func (vc *Connector) GetEnvironments(
 		var notFoundError *find.NotFoundError
 		vms, err := finder.VirtualMachineList(ctx, folderName+"*")
 		if errors.As(err, &notFoundError) {
-			slog.Info("no virtual machines found in folder", slog.String("folder", folderName))
+			slog.Info(
+				"no virtual machines found in folder",
+				slog.String("folder", folderName),
+			)
 		} else if err != nil {
 			return nil, fmt.Errorf("error finding vms: %w", err)
 		}
@@ -146,7 +149,10 @@ func (vc *Connector) GetEnvironments(
 		owner := parseAnnotation(vm.Summary.Config.Annotation, "EC_OWNER")
 		ttl := parseAnnotation(vm.Summary.Config.Annotation, "EC_TTL")
 		if owner == "" || ttl == "" {
-			slog.Warn("skipped VM: owner or ttl is empty", slog.String("name", vm.Name))
+			slog.Warn(
+				"skipped VM: owner or ttl is empty",
+				slog.String("name", vm.Name),
+			)
 			envTmp := &model.Environment{
 				Name: vm.Name,
 				Type: connectorType,
@@ -328,7 +334,10 @@ func (vc *Connector) searchVMbyName(
 	if len(objs) == 0 {
 		return "", fmt.Errorf("error finding vm: %w", errors.New("vm not found"))
 	} else if len(objs) > 1 {
-		return "", fmt.Errorf("error finding vm: %w", errors.New("multiple vms found"))
+		return "", fmt.Errorf(
+			"error finding vm: %w",
+			errors.New("multiple vms found"),
+		)
 	}
 
 	vmID := objs[0].Value

--- a/internal/model/connector.go
+++ b/internal/model/connector.go
@@ -11,4 +11,3 @@ type Connector interface {
 	GetEnvironments(ctx context.Context) ([]Environment, error)
 	GetEnvironmentID(ctx context.Context, env *Environment) (string, error)
 }
-

--- a/internal/storage/postgresql/postgresql.go
+++ b/internal/storage/postgresql/postgresql.go
@@ -337,7 +337,6 @@ func (s *Storage) Close() error {
 	return s.DB.Close()
 }
 
-
 func (s *Storage) getEnvironments(
 	ctx context.Context,
 	query string,

--- a/internal/storage/sqlite/sqlite.go
+++ b/internal/storage/sqlite/sqlite.go
@@ -134,7 +134,13 @@ func (s *Storage) WriteEnvironments(
 			)
 
 			if _, err := stmt.Exec(
-				e.EnvID, e.Type, e.Name, e.Namespace, e.Owner, e.DeleteAt, e.DeleteAtSec,
+				e.EnvID,
+				e.Type,
+				e.Name,
+				e.Namespace,
+				e.Owner,
+				e.DeleteAt,
+				e.DeleteAtSec,
 			); err != nil {
 				return err
 			}
@@ -342,7 +348,6 @@ func (s *Storage) executeTransaction(
 func (s *Storage) Close() error {
 	return s.DB.Close()
 }
-
 
 func (s *Storage) getEnvironments(
 	ctx context.Context,

--- a/internal/velero-backup/backup.go
+++ b/internal/velero-backup/backup.go
@@ -70,7 +70,10 @@ func (v *VeleroBackup) Create(
 		return err
 	}
 
-	slog.Info("backup request submitted successfully", slog.String("name", backupName))
+	slog.Info(
+		"backup request submitted successfully",
+		slog.String("name", backupName),
+	)
 
 	return nil
 }
@@ -91,7 +94,11 @@ func checkBackupStatus(v *VeleroBackup, backupName string) error {
 			if backupStatus.Status.Phase == velerov1api.BackupPhaseFailedValidation ||
 				backupStatus.Status.Phase == velerov1api.BackupPhasePartiallyFailed ||
 				backupStatus.Status.Phase == velerov1api.BackupPhaseFailed {
-				return fmt.Errorf("backup %q failed with status %q", backupName, backupStatus.Status.Phase)
+				return fmt.Errorf(
+					"backup %q failed with status %q",
+					backupName,
+					backupStatus.Status.Phase,
+				)
 			}
 
 			time.Sleep(5 * time.Second)

--- a/pkg/notificator/slack.go
+++ b/pkg/notificator/slack.go
@@ -44,7 +44,11 @@ func (nt *SlackNotificator) Send(msg *SlackMessage) error {
 		return fmt.Errorf("error marshaling slack message: %w", err)
 	}
 
-	resp, err := http.Post(nt.WebhookURL, "application/json", bytes.NewBuffer(body))
+	resp, err := http.Post(
+		nt.WebhookURL,
+		"application/json",
+		bytes.NewBuffer(body),
+	)
 	if err != nil {
 		return fmt.Errorf("error sending slack notification: %w", err)
 	}


### PR DESCRIPTION
## Summary
- Apply golines formatting (80 char line limit) to all Go files in the project
- Break long function calls, slog statements, and error wrapping across multiple lines
- Remove extra blank lines