### PR TITLE
refactor(api): REST-compliant endpoints and OpenAPI specification

### DIFF
--- a/internal/api/dto.go
+++ b/internal/api/dto.go
@@ -56,3 +56,9 @@ func NewEnvironmentListResponse(
 	}
 	return result
 }
+
+// ExtendEnvironmentRequest is a DTO for extending an environment's TTL.
+type ExtendEnvironmentRequest struct {
+	Period string `json:"period"`
+	Token  string `json:"token"`
+}

--- a/internal/api/environments_handler.go
+++ b/internal/api/environments_handler.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net/http"
+
+	"github.com/go-chi/chi/v5"
 )
 
 type EnvironmentHandler struct {
@@ -57,12 +59,16 @@ func (h *EnvironmentHandler) ExtendEnvironment(
 	r *http.Request,
 ) {
 	ctx := r.Context()
-	queryParams := r.URL.Query()
-	envID := queryParams.Get("env_id")
-	period := queryParams.Get("period")
-	token := queryParams.Get("token")
+	envID := chi.URLParam(r, "id")
 
-	env, err := h.service.ExtendEnvironment(ctx, envID, period, token)
+	var req ExtendEnvironmentRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		slog.Error("error decoding request", slog.Any("error", err))
+		sendErrorResponse(w, http.StatusBadRequest, "error decoding request")
+		return
+	}
+
+	env, err := h.service.ExtendEnvironment(ctx, envID, req.Period, req.Token)
 	if err != nil {
 		handleServiceError(w, err, envID)
 		return
@@ -72,10 +78,8 @@ func (h *EnvironmentHandler) ExtendEnvironment(
 		slog.String("name", env.DisplayName()),
 		slog.String("type", env.Type),
 		slog.String("id", env.EnvID),
-		slog.String("period", period),
+		slog.String("period", req.Period),
 	)
 
-	sendSuccessResponse(
-		w, NewEnvironmentResponse(env),
-	)
+	sendSuccessResponse(w, NewEnvironmentResponse(env))
 }

--- a/internal/api/environments_handler.go
+++ b/internal/api/environments_handler.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net/http"
-
-	"github.com/go-chi/chi/v5"
 )
 
 type EnvironmentHandler struct {
@@ -59,7 +57,7 @@ func (h *EnvironmentHandler) ExtendEnvironment(
 	r *http.Request,
 ) {
 	ctx := r.Context()
-	envID := chi.URLParam(r, "id")
+	envID := r.PathValue("id")
 
 	var req ExtendEnvironmentRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {

--- a/internal/api/openapi.go
+++ b/internal/api/openapi.go
@@ -1,0 +1,15 @@
+package api
+
+import (
+	_ "embed"
+	"net/http"
+)
+
+//go:embed openapi.yaml
+var openAPISpec []byte
+
+func serveOpenAPISpec(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/yaml; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(openAPISpec)
+}

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -26,6 +26,11 @@ components:
     Environment:
       type: object
       description: A managed environment registered for lifecycle tracking.
+      required:
+        - env_id
+        - type
+        - name
+        - owner
       properties:
         env_id:
           type: string
@@ -50,17 +55,17 @@ components:
           example: "john.doe"
         delete_at:
           type: string
-          description: Scheduled deletion timestamp (RFC3339).
+          description: Scheduled deletion timestamp.
           example: "2024-01-15 10:00:00"
-      required:
-        - env_id
-        - type
-        - name
-        - owner
 
     CreateEnvironmentRequest:
       type: object
       description: Payload for registering a new environment.
+      required:
+        - name
+        - owner
+        - type
+        - ttl
       properties:
         name:
           type: string
@@ -81,42 +86,44 @@ components:
           example: "helm"
         ttl:
           type: string
-          description: |
-            Time-to-live duration after which the environment is deleted.
-            Supports: `Xd` (days), `Xh` (hours), `Xw` (weeks).
+          description: "Time-to-live duration after which the environment is deleted. Supports: Xd (days), Xh (hours), Xw (weeks)."
           example: "7d"
-      required:
-        - name
-        - owner
-        - type
-        - ttl
 
     ExtendEnvironmentRequest:
       type: object
       description: Payload for extending an environment's TTL.
+      required:
+        - period
+        - token
       properties:
         period:
           type: string
-          description: |
-            Extension period added to the current deletion date.
-            Supports: `Xd` (days), `Xh` (hours), `Xw` (weeks).
+          description: "Extension period added to the current deletion date. Supports: Xd (days), Xh (hours), Xw (weeks)."
           example: "7d"
         token:
           type: string
           description: One-time authentication token issued to the environment owner.
           example: "abc123token"
-      required:
-        - period
-        - token
 
-    SuccessResponse:
+    EnvironmentResponse:
       type: object
       properties:
         success:
           type: boolean
           example: true
         data:
-          description: Response payload (type depends on the endpoint).
+          $ref: '#/components/schemas/Environment'
+
+    EnvironmentListResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+          example: true
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/Environment'
 
     ErrorResponse:
       type: object
@@ -150,14 +157,7 @@ paths:
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/SuccessResponse'
-                  - type: object
-                    properties:
-                      data:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/Environment'
+                $ref: '#/components/schemas/EnvironmentListResponse'
         "401":
           description: Missing or invalid API key.
           content:
@@ -197,12 +197,7 @@ paths:
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/SuccessResponse'
-                  - type: object
-                    properties:
-                      data:
-                        $ref: '#/components/schemas/Environment'
+                $ref: '#/components/schemas/EnvironmentResponse'
         "400":
           description: Invalid request payload.
           content:
@@ -240,7 +235,7 @@ paths:
         - name: id
           in: path
           required: true
-          description: Unique environment identifier (`env_id`).
+          description: Unique environment identifier (env_id).
           schema:
             type: string
           example: "a1b2c3d4"
@@ -259,12 +254,7 @@ paths:
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/SuccessResponse'
-                  - type: object
-                    properties:
-                      data:
-                        $ref: '#/components/schemas/Environment'
+                $ref: '#/components/schemas/EnvironmentResponse'
         "400":
           description: Invalid request payload or token.
           content:
@@ -283,16 +273,3 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-
-  /api/openapi.yaml:
-    get:
-      summary: OpenAPI specification
-      description: Returns this OpenAPI 3.0 specification in YAML format.
-      operationId: getOpenAPISpec
-      responses:
-        "200":
-          description: OpenAPI specification.
-          content:
-            application/yaml:
-              schema:
-                type: string

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -1,0 +1,298 @@
+openapi: 3.0.3
+info:
+  title: env-cleaner API
+  description: |
+    API for managing temporary environments lifecycle.
+
+    Environments (Helm releases, vSphere VMs) are registered with a TTL and
+    automatically deleted when they expire. Owners receive email notifications
+    with a link to extend the environment lifetime if needed.
+  version: 1.0.0
+
+servers:
+  - url: http://localhost:8080
+    description: Local development server
+
+components:
+  securitySchemes:
+    basicAuth:
+      type: http
+      scheme: basic
+      description: |
+        Send `Authorization: Basic <base64(api_key)>` where `api_key` is the
+        value of the `admin_api_key` server configuration option.
+
+  schemas:
+    Environment:
+      type: object
+      description: A managed environment registered for lifecycle tracking.
+      properties:
+        env_id:
+          type: string
+          description: Unique environment identifier.
+          example: "a1b2c3d4"
+        type:
+          type: string
+          description: Environment type.
+          enum: [helm, vsphere_vm]
+          example: "helm"
+        name:
+          type: string
+          description: Environment name (Helm release name or VM name).
+          example: "feature-branch-42"
+        namespace:
+          type: string
+          description: Kubernetes namespace (Helm environments only).
+          example: "dev"
+        owner:
+          type: string
+          description: Email or username of the environment owner.
+          example: "john.doe"
+        delete_at:
+          type: string
+          description: Scheduled deletion timestamp (RFC3339).
+          example: "2024-01-15 10:00:00"
+      required:
+        - env_id
+        - type
+        - name
+        - owner
+
+    CreateEnvironmentRequest:
+      type: object
+      description: Payload for registering a new environment.
+      properties:
+        name:
+          type: string
+          description: Environment name (Helm release name or VM name).
+          example: "feature-branch-42"
+        namespace:
+          type: string
+          description: Kubernetes namespace (Helm environments only).
+          example: "dev"
+        owner:
+          type: string
+          description: Email or username of the environment owner.
+          example: "john.doe"
+        type:
+          type: string
+          description: Environment type.
+          enum: [helm, vsphere_vm]
+          example: "helm"
+        ttl:
+          type: string
+          description: |
+            Time-to-live duration after which the environment is deleted.
+            Supports: `Xd` (days), `Xh` (hours), `Xw` (weeks).
+          example: "7d"
+      required:
+        - name
+        - owner
+        - type
+        - ttl
+
+    ExtendEnvironmentRequest:
+      type: object
+      description: Payload for extending an environment's TTL.
+      properties:
+        period:
+          type: string
+          description: |
+            Extension period added to the current deletion date.
+            Supports: `Xd` (days), `Xh` (hours), `Xw` (weeks).
+          example: "7d"
+        token:
+          type: string
+          description: One-time authentication token issued to the environment owner.
+          example: "abc123token"
+      required:
+        - period
+        - token
+
+    SuccessResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+          example: true
+        data:
+          description: Response payload (type depends on the endpoint).
+
+    ErrorResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+          example: false
+        error:
+          type: object
+          properties:
+            code:
+              type: integer
+              description: HTTP status code.
+              example: 400
+            message:
+              type: string
+              description: Human-readable error description.
+              example: "validation error: ttl is required"
+
+paths:
+  /api/environments:
+    get:
+      summary: List environments
+      description: Returns all environments currently tracked by env-cleaner.
+      operationId: listEnvironments
+      security:
+        - basicAuth: []
+      responses:
+        "200":
+          description: Successful response with environment list.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/SuccessResponse'
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/Environment'
+        "401":
+          description: Missing or invalid API key.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+    post:
+      summary: Register environment
+      description: |
+        Registers a new environment for lifecycle management. The environment
+        will be automatically deleted once its TTL expires.
+      operationId: createEnvironment
+      security:
+        - basicAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateEnvironmentRequest'
+            example:
+              name: "feature-branch-42"
+              namespace: "dev"
+              owner: "john.doe"
+              type: "helm"
+              ttl: "7d"
+      responses:
+        "200":
+          description: Environment registered successfully.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/SuccessResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/Environment'
+        "400":
+          description: Invalid request payload.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "401":
+          description: Missing or invalid API key.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "409":
+          description: An environment with the same name already exists.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /api/environments/{id}/extend:
+    post:
+      summary: Extend environment TTL
+      description: |
+        Extends the scheduled deletion date of an environment by the given period.
+        Uses a one-time token issued to the environment owner (delivered via email).
+        No API key is required — the token authenticates the request.
+      operationId: extendEnvironment
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Unique environment identifier (`env_id`).
+          schema:
+            type: string
+          example: "a1b2c3d4"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ExtendEnvironmentRequest'
+            example:
+              period: "7d"
+              token: "abc123token"
+      responses:
+        "200":
+          description: Environment extended successfully.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/SuccessResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/Environment'
+        "400":
+          description: Invalid request payload or token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "404":
+          description: Environment not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /api/openapi.yaml:
+    get:
+      summary: OpenAPI specification
+      description: Returns this OpenAPI 3.0 specification in YAML format.
+      operationId: getOpenAPISpec
+      responses:
+        "200":
+          description: OpenAPI specification.
+          content:
+            application/yaml:
+              schema:
+                type: string

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -63,30 +63,19 @@ func (a *API) Run(ctx context.Context) error {
 
 	r.Group(func(r chi.Router) {
 		r.Get("/extend", extendPage.ServePage)
-		r.Get(
-			"/extend/apply",
-			envHandler.ExtendEnvironment,
-		)
-		r.Get(
-			"/extend/static/extend.css",
-			extendPage.ServeCSS,
-		)
-		r.Get(
-			"/extend/static/extend.js",
-			extendPage.ServeJS,
-		)
+		r.Get("/extend/static/extend.css", extendPage.ServeCSS)
+		r.Get("/extend/static/extend.js", extendPage.ServeJS)
 	})
 
 	r.Group(func(r chi.Router) {
 		r.Use(a.authMiddleware)
-		r.Get(
-			"/api/environments",
-			envHandler.GetEnvironments,
-		)
-		r.Post(
-			"/api/environments",
-			envHandler.AddEnvironment,
-		)
+		r.Get("/api/environments", envHandler.GetEnvironments)
+		r.Post("/api/environments", envHandler.AddEnvironment)
+	})
+
+	r.Group(func(r chi.Router) {
+		r.Post("/api/environments/{id}/extend", envHandler.ExtendEnvironment)
+		r.Get("/api/openapi.yaml", serveOpenAPISpec)
 	})
 
 	srv := &http.Server{

--- a/internal/api/static/extend.js
+++ b/internal/api/static/extend.js
@@ -4,15 +4,16 @@ function extend(period) {
     btn.disabled = true;
   });
 
-  var url =
-    "/extend/apply?env_id=" +
-    encodeURIComponent(envID) +
-    "&period=" +
-    encodeURIComponent(period) +
-    "&token=" +
-    encodeURIComponent(token);
-
-  fetch(url)
+  fetch("/api/environments/" + encodeURIComponent(envID) + "/extend", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      period: period,
+      token: token
+    })
+  })
     .then(function (resp) {
       return resp.json().then(function (data) {
         return { ok: resp.ok, data: data };


### PR DESCRIPTION
## What changed

### Problems with the old API
- `GET /extend/apply` — a state-mutating operation (extending TTL) via GET request, which violates REST semantics
- Parameters (`env_id`, `period`, `token`) were passed via query string instead of the request body
- No machine-readable API specification

### Changes

#### Renamed extend endpoint
| Before | After |
|--------|-------|
| `GET /extend/apply?env_id=X&period=Y&token=Z` | `POST /api/environments/{id}/extend` |

Token and period are now passed in the JSON request body:
```json
{ "period": "7d", "token": "abc123" }
```

#### Final routes
| Method | Path | Auth | Description |
|--------|------|------|-------------|
| `GET` | `/extend` | — | HTML page for environment extension |
| `GET` | `/extend/static/extend.css` | — | Extension page styles |
| `GET` | `/extend/static/extend.js` | — | Extension page JS |
| `GET` | `/api/environments` | Basic Auth | List environments |
| `POST` | `/api/environments` | Basic Auth | Register environment |
| `POST` | `/api/environments/{id}/extend` | Token in body | Extend environment TTL |
| `GET` | `/api/openapi.yaml` | — | OpenAPI specification |

#### New OpenAPI specification
- File: `internal/api/openapi.yaml` (OpenAPI 3.0.3)
- Embedded in binary and served at `GET /api/openapi.yaml`
- Covers all endpoints with request/response schemas, examples and error codes

#### Updated `extend.js`
- Switched from `fetch(GET url)` to `fetch(POST, JSON body)` to call the new endpoint

#### Handler cleanup
- Replaced `chi.URLParam(r, "id")` with `r.PathValue("id")` (standard library, Go 1.22+)
- chi v5.0.12+ populates `PathValue` automatically, so the chi import is no longer needed in the handler

## Test plan
- [ ] `GET /api/environments` returns list with Basic Auth
- [ ] `POST /api/environments` creates environment with Basic Auth
- [ ] `POST /api/environments/{id}/extend` extends TTL using token
- [ ] `GET /extend` renders HTML page, extension buttons work correctly
- [ ] `GET /api/openapi.yaml` returns valid YAML
- [ ] Project compiles without errors (`go build ./...`)

https://claude.ai/code/session_01451ABxe84QZCsyoggrJbXG